### PR TITLE
Fix incorrect party size in SCB algorithm, lower 2 member party SSC gain

### DIFF
--- a/recalculate.py
+++ b/recalculate.py
@@ -58,6 +58,7 @@ async def calculate():
             created_at=log["party_created_at"],
             finished_at=log["party_finished_at"],
             size=log["party_size"],
+            members=[PartyMember(0, "") for _ in range(log["party_size"])],
         )
         if log["new_sail_credit"] - log["prev_sail_credit"] < 0:
             await scb.process_flaked_user(


### PR DESCRIPTION
- Multiply SSC gain by 0.6 for 2 member parties
- Fix party size for debits and credits
    - Use the length of party members instead of max size
- Limit penalty to current SSC to prevent negative SSC